### PR TITLE
Fix package.json "main" to point proper entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "simple-exiftool",
   "version": "1.1.0",
   "description": "Extracting metadata from media files with exiftool, including but not limited to mp4, mov, 3gp, jpg, png, gif, pdf.",
-  "main": "./lib/exif",
+  "main": "./lib/index",
   "scripts": {
     "test": "./node_modules/.bin/mocha ./test"
   },


### PR DESCRIPTION
Require under node16 raises warning:

> [DEP0128] DeprecationWarning: Invalid 'main' field in '/npm-image-processor/node_modules/simple-exiftool/package.json' of './lib/exif'. Please either fix that or report it to the module author

Any chance to get this merged and a new version published?